### PR TITLE
Fix Compile Issue

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -141,7 +141,7 @@ add_library(${PROJECT_NAME} include/${PROJECT_NAME}/occupancyMap.cpp
 ## Add cmake target dependencies of the library
 ## as an example, code may need to be generated before libraries
 ## either from message generation or dynamic reconfigure
-# add_dependencies(${PROJECT_NAME} ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
+add_dependencies(${PROJECT_NAME} ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
 
 ## Declare a C++ executable
 ## With catkin_make all packages are built within a single CMake context


### PR DESCRIPTION
Allow messages & services to-be built first, to avoid compilation at the first time to resolve issue such as  https://github.com/Zhefan-Xu/map_manager/issues/5